### PR TITLE
fixing context init for multi threads

### DIFF
--- a/src/pg_query.c
+++ b/src/pg_query.c
@@ -5,7 +5,7 @@
 
 const char* progname = "pg_query";
 
-sig_atomic_t pg_query_initialized = 0;
+__thread sig_atomic_t pg_query_initialized = 0;
 
 void pg_query_init(void)
 {


### PR DESCRIPTION
unit test with the script:
```
from pglast import parse_sql
import time
import threading

#cmd = 'SELECT * FROM (SELECT DISTINCT ON (Item) "Item", "Location" FROM "adam/UN"."t10" ORDER BY "Item", "Location" DESC) ORDER BY "Location" DESC;'
cmd = 'SELECT * FROM (SELECT DISTINCT ON (Item) "Item", "Location" FROM "adam/UN"."t10" ORDER BY "Item", "Location" DESC) a ORDER BY "Location" DESC;'

def parser():
	try:
		try:
			parse_sql(cmd)
            print("all good.")
		except Exception as e:
			print(e)
			raise
	except:
		time.sleep(1)
		pass

for i in range(100):
	x = threading.Thread(target=parser)
	time.sleep(1)
	x.start()

while 1:
	pass
```